### PR TITLE
fix mac address sparated by - (dash)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(macAddress){
     var macRegExp = /(([0-9A-Fa-f][0-9A-Fa-f][-:]){5}[0-9A-Fa-f][0-9A-Fa-f])|(([0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f].){2}[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f])/;
     if (!macRegExp.test(mac)) return {key: mac, vendorMacPrefix: '', shortTitle: '', fullTitle: ''};
 
-    var macSplit = macAddress.toLowerCase().split(':');
+    var macSplit = macAddress.toLowerCase().replace(/-/g, ':').split(':');
     var mac5 = macSplit.reduce(function(prev, current, index) {
         return (index <5) ? prev + ':'+ current : prev
     });


### PR DESCRIPTION
Hello.
I write small dhcp server for SIP Phone provisioning .
I tried your node-detect-hardware-vendor-by-mac with dashed separated mac address.
eg:
const detectByMac = require('detect-hardware-vendor-by-mac'); 
const str = 'BC-C3-42-A9-F2-AF'; // NG JSON is empty
const str = 'BC:C3:42:A9:F2:AF'; // off cource OK
const info = detectByMac(str);

and I check source code . seem to work split() function is only work in case : separated .

Please review and fix your greate work.
